### PR TITLE
Api redesign

### DIFF
--- a/examples/thpool_easy_example.c
+++ b/examples/thpool_easy_example.c
@@ -16,7 +16,7 @@
 #include <stdint.h>
 #include "threadpool.h"
 
-void task(thpool_arg arg, void ** _){
+void task(threadpool_arg arg, threadpool_thread _){
     printf("Thread #%u working on %d\n", (unsigned)pthread_self(), (int) arg.val);
 }
 
@@ -32,7 +32,7 @@ int main(){
     printf("Adding 40 tasks to threadpool\n");
     int i;
     for (i=0; i<40; i++){
-        thpool_arg arg = {.val = i};
+        threadpool_arg arg = {.val = i};
         thpool_add_work(thpool, task, arg);
     };
 

--- a/readme.md
+++ b/readme.md
@@ -157,13 +157,15 @@ In this case, make sure you do not include `"utils/log.h"` or define macros mapp
 #define thpool_log_debug(fmt, ...) fprintf(stdout, "THPOOL_DEBUG: " fmt "\n" __VA_OPT__(,) __VA_ARGS__)
 #define thpool_log_info(fmt, ...)  fprintf(stdout, "THPOOL_INFO: " fmt "\n" __VA_OPT__(,) __VA_ARGS__)
 #define thpool_log_warn(fmt, ...)  fprintf(stderr, "THPOOL_WARN: " fmt "\n" __VA_OPT__(,) __VA_ARGS__)
-#define thpool_log_error(fmt, ...) do { fprintf(stderr, "THPOOL_ERROR: " fmt "\n" __VA_OPT__(,) __VA_ARGS__); /* Handle fatal error, e.g., abort() */ abort(); } while(0)
+#define thpool_log_error(fmt, ...)  fprintf(stderr, "THPOOL_ERROR: " fmt "\n" __VA_OPT__(,) __VA_ARGS__)
+#define thpool_log_fatal(fmt, ...) do { fprintf(stderr, "THPOOL_FATAL: " fmt "\n" __VA_OPT__(,) __VA_ARGS__); /* Handle fatal error, e.g., abort() */ abort(); } while(0)
 
 // Or define as empty to disable logging (error logging should typically still cause program termination)
 // #define THPOOL_LOG_DEBUG(fmt, ...)
 // #define THPOOL_LOG_INFO(fmt, ...)
 // #define THPOOL_LOG_WARN(fmt, ...)
-// #define THPOOL_LOG_ERROR(fmt, ...) do { abort(); } while(0)
+// #define THPOOL_LOG_ERROR(fmt, ...)
+// #define THPOOL_LOG_FATAL(fmt, ...) do { abort(); } while(0)
 // ... Define other levels similarly ...
 
 // --- If using the provided default logging, see "Option 1" above ---

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,6 @@
  *  \section    examples                                    Examples
  *  \section    api-overview                                API Overview
  *  \section    structures                                  Structures
- *  \section    note-on-container_of-usage-for-thread-info  Note on `container_of` Usage for Thread Info
  *  \section    included-components-and-licensing           Included Components and Licensing
  */
 -->
@@ -40,10 +39,8 @@ During the modification process, several areas were refined or reimplemented:
 * **Thread Context and Callbacks:** Added support for thread-specific context (`thread_ctx_slot`) and callbacks executed when a thread starts (`thread_start_cb`) or finishes (`thread_end_cb`). This enables sharing resources or maintaining state across tasks executed by the same thread.
 * **Enhanced configuration options, including control over the maximum job queue size:** This allows preventing excessive memory usage by the queue and provides waiting/notification mechanisms when the queue is full.
 * **Semaphore Implementation:** The original project's custom binary semaphore implementation, which presented some unexpected behaviors and potential performance limitations in our testing, was replaced entirely. This version utilizes standard POSIX mutexes and condition variables for synchronization, aiming for more predictable and robust behavior.
-* **Task Argument Handling:** To provide a more explicit and potentially safer way to pass arguments to task functions, the single `void*` argument was replaced with a `thpool_arg` union. This allows users to clearly indicate whether they are passing a small value (`val`) or a pointer (`ptr`).
+* **Task Argument Handling:** To provide a more explicit and potentially safer way to pass arguments to task functions, the single `void*` argument was replaced with a `threadpool_arg` union. This allows users to clearly indicate whether they are passing a small value (`val`) or a pointer (`ptr`).
 * **Lifecycle Control:** The thread pool shutdown and resource destruction phases were explicitly separated (`thpool_shutdown` and `thpool_destroy`) to offer finer control over the pool's lifecycle.
-
-While the original project aimed for strict ANSI C and POSIX compliance, this version, due to the practical need for accessing thread metadata from task contexts, utilizes the `container_of` macro. While widely used in practice (notably in the Linux kernel) and generally reliable on common platforms and compilers, it is worth noting that the pointer arithmetic involved can be considered theoretically outside the strictest interpretation of the C standard regarding pointer provenance. Users in highly constrained or non-standard environments should be mindful of this.
 
 We hope these modifications make the library more flexible and suitable for a wider range of applications, while building upon the strong foundation laid by Pithikos's original work.
 
@@ -72,7 +69,7 @@ This library includes enhancements and modifications compared to the base Pithik
 * 增强的配置选项，包括控制最大任务队列大小。这有助于防止队列过度占用内存，并在队列满时提供等待/通知机制。
 * 集成了日志功能（通过`threadpool_log_config.h`进行配置，并提供基于`rxi/log.c`的可选默认实现）。
 * 引入了调试用并发通行证及其相关的API变种，用于帮助诊断线程池生命周期相关的并发问题（例如UAF）。这些可选的调试API通过在包含`threadpool.h`之前定义宏 `THPOOL_ENABLE_DEBUG_CONC_API`来启用。有关调试用并发特性的详细用法和API参考，请查阅`threadpool.h`头文件中的注释。
-* 使用`thpool_arg` Union处理任务参数，方式灵活，可以清晰地传递值或指针。
+* 使用`threadpool_arg` Union处理任务参数，方式灵活，可以清晰地传递值或指针。
 * 将线程池的关闭 (`thpool_shutdown`) 与资源销毁 (`thpool_destroy`) 分离，提供了更精细的控制。
 
 **移除特性：**
@@ -187,8 +184,8 @@ Once the source files are included and logging is handled according to Option 1 
 #include "threadpool.h"
 #include "threadpool_log_config.h" // Include this to use thpool_log_* in this file
 
-// Define a task function matching the signature void (*function_p)(thpool_arg arg, void** thread_ctx_location)
-void my_task(thpool_arg arg, void** thread_ctx_location) {
+// Define a task function matching the signature void (*function_p)(threadpool_arg arg, void** thread_ctx_location)
+void my_task(threadpool_arg arg, void** thread_ctx_location) {
     // ... task logic ...
     // Use the abstract logging interfaces defined in threadpool_log_config.h
     thpool_log_debug("Task executed, arg value: %lld", arg.val);
@@ -213,7 +210,7 @@ int main() {
     }
 
     // Add work
-    thpool_arg task_arg = {.val = 123};
+    threadpool_arg task_arg = {.val = 123};
     thpool_log_info("Adding first task");
     thpool_add_work(pool, my_task, task_arg);
 
@@ -241,7 +238,7 @@ These examples demonstrate:
 * Basic thread pool initialization and task submission.
 * Using thread start and end callbacks.
 * Passing and utilizing thread-specific context data.
-* Handling task arguments with the `thpool_arg` union.
+* Handling task arguments with the `threadpool_arg` union.
 * Demonstrating thread pool shutdown and destruction.
 * More complex scenarios involving waiting for tasks or managing queue full conditions.
 
@@ -254,7 +251,7 @@ Building and running these examples can provide practical insights into how to b
 * 线程池的基础初始化和任务提交。
 * 使用线程启动和结束回调。
 * 传递和利用线程特定的上下文数据。
-* 使用`thpool_arg` Union处理任务参数。
+* 使用`threadpool_arg` Union处理任务参数。
 * 演示线程池的关闭和销毁流程。
 * 涉及等待任务或处理队列满条件等更复杂的场景。
 
@@ -295,7 +292,7 @@ Replace `thpool_easy_example` with the name of the example program you wish to r
 Here are some of the key functions provided by the library:
 
 * **`threadpool thpool_init(threadpool_config *conf)`**: Initializes a thread pool with the specified configuration.
-* **`int thpool_add_work(threadpool pool, void (*function_p)(thpool_arg, void**), thpool_arg arg_p)`**: Adds work (a task function and its argument) to the thread pool's job queue.
+* **`int thpool_add_work(threadpool pool, void (*function_p)(threadpool_arg, void**), threadpool_arg arg_p)`**: Adds work (a task function and its argument) to the thread pool's job queue.
 * **`int thpool_wait(threadpool)`**: Blocks the calling thread until all queued jobs and currently executing jobs have finished.
 * **`int thpool_reactivate(threadpool)`**: Resumes thread pool activity after being paused by `thpool_wait`.
 * **`int thpool_num_threads_working(threadpool)`**: Gets the current number of threads actively working on a job.
@@ -308,25 +305,9 @@ Here are some of the key functions provided by the library:
 ## Structures
 
 * **`threadpool`**: An opaque handle for the thread pool.
-* **`thpool_arg`**: Flexible union to carry arguments for task and callback functions (value or pointer).
+* **`threadpool_arg`**: Flexible union to carry arguments for task and callback functions (value or pointer).
 * **`threadpool_config`**: Structure used to configure the thread pool during initialization.
 * **`thpool_debug_conc_passport`**: An opaque handle for the debug concurrency passport (used with `THPOOL_ENABLE_DEBUG_CONC_API`).
-
-## Note on `container_of` Usage for Thread Info
-
-When retrieving thread-specific metadata using functions like `thpool_thread_get_id` and `thpool_thread_get_name`, this library internally utilizes a common C idiom based on the `container_of` macro (similar to the one used in the Linux kernel).
-
-This technique allows the library to return a pointer to a member within an internal thread structure (the `thread_ctx_slot` member within the `thread` structure) and then calculate the address of the containing `thread` structure from that member's address and its known offset. **The calculation involves casting the member pointer to a `uintptr_t` (an unsigned integer type guaranteed to hold a pointer value), performing integer subtraction of the member's offset, and then casting the resulting integer address back to a pointer to the containing structure.**
-
-The primary motivation for this approach is to keep the internal `thread` structure opaque to the user, providing better encapsulation, while still allowing access to essential metadata associated with the executing thread.
-
-It is important to be aware that, according to a strict interpretation of the standard C language rules, particularly concerning pointer provenance and the validity of pointers obtained through non-standard means (like arbitrary integer conversions and arithmetic), the pointer manipulation involved in `container_of` can still be considered theoretically "Undefined Behavior" (UB) when the resulting pointer is used to access the original object.
-
-However, this pattern, specifically using `uintptr_t` for the address calculation, is widely used in practice in many robust C projects (including the Linux kernel) precisely because it aligns well with how hardware treats pointers as memory addresses. In conjunction with the `offsetof` macro (which is standard and guaranteed not to cause UB for standard-layout structs), its behavior is generally reliable on most common architectures and with mainstream compilers (like GCC and Clang) that developers are likely to use. The use of `uintptr_t` is often considered a more portable and less compiler-optimization-sensitive way to perform this address calculation compared to casting to `char*` or performing arithmetic directly on unrelated pointer types.
-
-This implementation assumes that the compiler and target architecture behave in the typical manner where pointers can be safely round-tripped through `uintptr_t` for address calculations.
-
-**If you are working in a highly constrained environment, using an unusual architecture, or a non-standard compiler where you cannot verify the behavior of such pointer arithmetic and conversions, you might need to exercise caution or avoid using the `get thread info` series of functions.** In typical development scenarios on standard platforms, this usage is generally considered safe and reliable in practice, despite the theoretical UB concern.
 
 ## Included Components and Licensing
 

--- a/src/threadpool.h
+++ b/src/threadpool.h
@@ -35,6 +35,8 @@ extern "C" {
  */
 typedef struct thpool_* threadpool;
 
+typedef struct thread_* threadpool_thread;
+
 /**
  * @brief Flexible argument carrier for task and callback functions.
  *
@@ -45,10 +47,10 @@ typedef struct thpool_* threadpool;
  * When passing a pointer to data, use the .ptr member.
  * See @ref thpool_add_work for detailed usage examples.
  */
-typedef union thpool_arg{
+typedef union threadpool_arg{
     long long val;
     void* ptr;
-} thpool_arg;
+} threadpool_arg;
 
 #ifdef THPOOL_ENABLE_DEBUG_CONC_API
 /**
@@ -135,20 +137,20 @@ typedef struct threadpool_config {
      * and initialized, but before it starts processing jobs.
      *
      * @param arg               The shared callback argument provided in @ref callback_arg.
-     * @param thread_ctx_out    Pointer to the thread's context pointer (void**).
-     * Users can set *thread_ctx_out to point to thread-specific data.
+     * @param threadpool_thread Current thread handle.
+     * Users can get access to thread-specific data and thread-metadata with current thread handle.
      */
-    void    (*thread_start_cb)(thpool_arg arg, void **thread_ctx_out);
+    void    (*thread_start_cb)(threadpool_arg arg, threadpool_thread);
     /**
      * @brief Callback function executed when a thread is about to exit.
      * 在线程结束时执行的回调。
      *
      * This function is called by a worker thread just before it terminates.
      *
-     * @param thread_ctx_out    Pointer to the thread's context pointer (void**).
-     * Users can access or clean up thread-specific data here.
+     * @param threadpool_thread Current thread handle.
+     * Users can get access to thread-specific data and thread-metadata with current thread handle.
      */
-    void    (*thread_end_cb)(void **thread_ctx_out);
+    void    (*thread_end_cb)(threadpool_thread);
     /**
      * @brief Shared argument passed to thread start callbacks.
      * 线程启动的回调参数。
@@ -163,7 +165,7 @@ typedef struct threadpool_config {
      * value via the `val` member, there are no lifetime concerns for the value itself.
      * See @ref callback_arg_destructor for cleanup of pointed-to data.
      */
-    thpool_arg  callback_arg;
+    threadpool_arg  callback_arg;
     /**
      * @brief Destructor function for @ref callback_arg.
      *
@@ -276,7 +278,7 @@ typedef struct threadpool_config {
  *     return 0;
  * }
  * // Assuming MyConfigStruct is defined elsewhere
- * // void my_thread_start_using_config(thpool_arg arg, void** ctx) {
+ * // void my_thread_start_using_config(threadpool_arg arg, threadpool_thread current_thrd) {
  * //     MyConfigStruct *config = (MyConfigStruct*)arg.ptr;
  * //     // ... use config->setting1 etc. ...
  * // }
@@ -284,7 +286,7 @@ typedef struct threadpool_config {
  * @example
  * // Example 3: Initialization with callback_arg pointing to heap-allocated data + destructor
  * typedef struct { int resource_id; } ResourceData;
- * void cleanup_resource_data(thpool_arg arg); // User-defined cleanup function
+ * void cleanup_resource_data(threadpool_arg arg); // User-defined cleanup function
  * // ... main function ...
  * { // Create a new scope to manage memory
  *     ResourceData *res_data = malloc(sizeof(ResourceData));
@@ -315,8 +317,8 @@ typedef struct threadpool_config {
  * } // Scope ends
  *
  * // User-defined cleanup function
- * // void cleanup_resource_data(thpool_arg arg) {
- * //     // arg is a copy of the thpool_arg passed during init
+ * // void cleanup_resource_data(threadpool_arg arg) {
+ * //     // arg is a copy of the threadpool_arg passed during init
  * //     ResourceData *data_to_free = (ResourceData*)arg.ptr;
  * //     // ... perform any nested cleanup if needed ...
  * //     free(data_to_free); // Free the top-level block
@@ -405,12 +407,12 @@ int thpool_num_threads_working(threadpool);
  *
  * @param pool         The thread pool handle to which the work will be added.
  * @param function_p   Pointer to the task function to add as work.
- * The function should have the signature void (*)(thpool_arg arg, void** thread_ctx_out).
+ * The function should have the signature void (*)(threadpool_arg arg, threadpoolthread current_thrd).
  * Must not be NULL.
- * @param arg          The argument for the task function, encapsulated in a thpool_arg union.
+ * @param arg          The argument for the task function, encapsulated in a threadpool_arg union.
  * This argument is passed by value.
- * 使用一个联合体thpool_arg来定义你的参数。你的工作函数仅允许将该参数解释为val或ptr其一。
- * 你在传参时，应严格根据工作函数的解析方式约定你的thpool_arg的参数传递方式是val还是ptr。
+ * 使用一个联合体threadpool_arg来定义你的参数。你的工作函数仅允许将该参数解释为val或ptr其一。
+ * 你在传参时，应严格根据工作函数的解析方式约定你的threadpool_arg的参数传递方式是val还是ptr。
  *
  * @note The user is responsible for ensuring that any data pointed to by arg.ptr
  * remains valid until the task function finishes execution.
@@ -419,7 +421,7 @@ int thpool_num_threads_working(threadpool);
  * A separate destructor for task arguments is NOT provided by the library.
  * A common pattern is to pass pointers to heap-allocated data and free the memory inside the task function.
  * Passing pointers to stack-allocated data is generally unsafe unless you can strictly guarantee the lifetime.
- * 禁止在传参时以一种方式定义thpool_arg，而在工作函数中以另一种方式解析的情况发生。
+ * 禁止在传参时以一种方式定义threadpool_arg，而在工作函数中以另一种方式解析的情况发生。
  * 如果你的传入方式是ptr，即一个结构体指针，建议你传入堆上的指针，并在工作函数中传递到其他位置或销毁。
  * 如果传入栈上的指针，有可能会因为其生命周期结束，导致工作函数使用时发生错误。
  *
@@ -427,15 +429,15 @@ int thpool_num_threads_working(threadpool);
  *
  * @example
  * // Example 1: Adding a task with a simple integer value
- * void task_process_int(thpool_arg args, void** thread_ctx_out);
+ * void task_process_int(threadpool_arg args, threadpoolthread current_thrd);
  * // ... main function ...
  *     threadpool pool = thpool_init(&conf);
  *     // ...
  *     int value_to_process = 10;
- *     thpool_arg task_arg_int = {.val = value_to_process}; // Pass value by embedding in union
+ *     threadpool_arg task_arg_int = {.val = value_to_process}; // Pass value by embedding in union
  *     thpool_add_work(pool, task_process_int, task_arg_int); // Pass union value
  * // ...
- * void task_process_int(thpool_arg args, void** thread_ctx_out) {
+ * void task_process_int(threadpool_arg args, threadpoolthread current_thrd) {
  *     int num = (int)args.val; // Access the value (be mindful of narrowing conversion)
  *     printf("Processing integer: %d\n", num);
  *     // No free needed for a value
@@ -445,7 +447,7 @@ int thpool_num_threads_working(threadpool);
  * // Example 2: Adding a task with a pointer to heap-allocated data
  * // User is responsible for freeing the data pointed to by the pointer!
  * typedef struct { double x, y; } Point;
- * void task_process_point(thpool_arg args, void** thread_ctx_out);
+ * void task_process_point(threadpool_arg args, threadpoolthread current_thrd);
  * // ... main function ...
  *     threadpool pool = thpool_init(&conf);
  *     // ...
@@ -454,7 +456,7 @@ int thpool_num_threads_working(threadpool);
  *         // handle error  
  *     }
  *     my_point->x = 1.0; my_point->y = 2.5;
- *     thpool_arg task_arg_ptr = {.ptr = my_point}; // Pass pointer by embedding in union
+ *     threadpool_arg task_arg_ptr = {.ptr = my_point}; // Pass pointer by embedding in union
  *     thpool_add_work(pool, task_process_point, task_arg_ptr); // Pass union value containing pointer
  *
  * // ... Later in main or elsewhere, after submitting,
@@ -462,7 +464,7 @@ int thpool_num_threads_working(threadpool);
  * //     This requires coordination (e.g., task signals completion, or task frees itself).
  * //     A common pattern is for the task itself to free the memory it received via pointer.
  * // ...
- * void task_process_point(thpool_arg args, void** thread_ctx_out) {
+ * void task_process_point(threadpool_arg args, threadpoolthread current_thrd) {
  *     Point *p = (Point*)args.ptr; // Access the pointer
  *     printf("Processing point: (%f, %f)\n", p->x, p->y);
  *     free(p); // <-- Task takes responsibility for freeing heap data
@@ -474,15 +476,15 @@ int thpool_num_threads_working(threadpool);
  * @example
  * // Example 3: Adding a task with a pointer to stack-allocated data (DANGEROUS!)
  * // This will likely lead to a Use-After-Free error if the task runs after the calling function returns.
- * void task_use_stack_data(thpool_arg args, void** thread_ctx_out);
+ * void task_use_stack_data(threadpool_arg args, threadpoolthread current_thrd);
  * // ... inside some_function() { ...
  *     int local_value = 5;
- *     thpool_arg task_arg_stack = {.ptr = &local_value};
+ *     threadpool_arg task_arg_stack = {.ptr = &local_value};
  *     thpool_add_work(pool, task_use_stack_data, task_arg_stack); // DANGEROUS! Pointer becomes invalid when some_function returns.
  * // ... some_function returns ...
  * // ... task_use_stack_data runs later and uses invalid pointer ...
  * // }
- * // void task_use_stack_data(thpool_arg args, void** thread_ctx_out) {
+ * // void task_use_stack_data(threadpool_arg args, threadpoolthread current_thrd) {
  * //     int *num_ptr = (int*)args.ptr;
  * //     printf("Processing number: %d\n", *num_ptr); // CRASH or UB!
  * // }
@@ -491,7 +493,7 @@ int thpool_num_threads_working(threadpool);
  * memory's lifetime covers the entire execution of the task function. This is hard to ensure.
  * Prefer passing values or pointers to dynamically allocated or static storage duration data.
  */
-int thpool_add_work(threadpool, void (*function_p)(thpool_arg, void**), thpool_arg arg_p);
+int thpool_add_work(threadpool, void (*function_p)(threadpool_arg, threadpool_thread), threadpool_arg arg_p);
 
 /**
  * @brief Gets the ID of the current thread pool thread.
@@ -500,15 +502,11 @@ int thpool_add_work(threadpool, void (*function_p)(thpool_arg, void**), thpool_a
  * @ref thread_start_cb, @ref thread_end_cb, or a task function.
  * It retrieves the thread's internal ID from its thread context.
  *
- * @param thread_ctx_location A pointer to the thread's context pointer (void**),
+ * @param current_thrd  Current thread handle,
  * as passed to the callback or task function.
  * @return int The internal ID of the calling thread pool thread.
- * 
- * @note This function, along with @ref thpool_thread_get_name, relies on the `container_of`
- * macro internally. Please see the general note on `container_of` usage above for details
- * on potential theoretical undefined behavior and compiler support assumptions.
  */
-int thpool_thread_get_id(void **thread_ctx_location);
+int thpool_thread_get_id(threadpool_thread current_thrd);
 
 /**
  * @brief Gets the name of the current thread pool thread.
@@ -517,18 +515,20 @@ int thpool_thread_get_id(void **thread_ctx_location);
  * @ref thread_start_cb, @ref thread_end_cb, or a task function.
  * It retrieves the thread's name from its thread context.
  *
- * @param thread_ctx_location A pointer to the thread's context pointer (void**),
+ * @param current_thrd Current thread handle,
  * as passed to the callback or task function.
  * @return const char* A pointer to the null-terminated string containing the thread's name.
  * The returned pointer points to internal thread pool memory and must
  * not be modified or freed by the caller. The string is valid for
  * the lifetime of the thread.
- * 
- * @note This function, along with @ref thpool_thread_get_id, relies on the `container_of`
- * macro internally. Please see the general note on `container_of` usage above for details
- * on potential theoretical undefined behavior and compiler support assumptions.
  */
-const char* thpool_thread_get_name(void **thread_ctx_location);
+const char* thpool_thread_get_name(threadpool_thread current_thrd);
+
+void * thpool_thread_get_context(threadpool_thread current_thrd);
+
+void thpool_thread_set_context(threadpool_thread current_thrd, void *ctx);
+
+void thpool_thread_unset_context(threadpool_thread current_thrd);
 
 #ifdef THPOOL_ENABLE_DEBUG_CONC_API
 /**
@@ -574,7 +574,7 @@ void thpool_debug_conc_passport_destroy(thpool_debug_conc_passport);
  * @return int         0 on success, -1 otherwise (e.g., NULL handles, passport mismatch, or pool not in ALIVE state).
  * @note User is responsible for managing lifetime of data pointed to by `arg.ptr`.
  */
-int thpool_add_work_debug_conc(threadpool, thpool_debug_conc_passport, void (*function_p)(thpool_arg, void**), thpool_arg arg_p);
+int thpool_add_work_debug_conc(threadpool, thpool_debug_conc_passport, void (*function_p)(threadpool_arg, threadpool_thread), threadpool_arg arg_p);
 
 /**
  * @brief Waits for all queued jobs to finish using a user-provided passport for diagnosis.

--- a/src/threadpool.h
+++ b/src/threadpool.h
@@ -530,6 +530,13 @@ void thpool_thread_set_context(threadpool_thread current_thrd, void *ctx);
 
 void thpool_thread_unset_context(threadpool_thread current_thrd);
 
+/**
+ * 若用户传入的回调参数有析构函数，默认会在线程结束时解除引用。所有线程都解除引用时，回调参数会执行用户传入的析构函数。
+ * 如果想要提前解除引用，可以在线程开始回调里使用完回调参数后就手动解除引用。
+ * 如果用户这么做，则不得再在同一线程内使用回调参数，否则可能导致UAF。
+ */
+void thpool_thread_unref_callback_arg(threadpool_thread current_thrd);
+
 #ifdef THPOOL_ENABLE_DEBUG_CONC_API
 /**
  * @brief Initializes a debug concurrency passport.

--- a/src/threadpool_log_config.h
+++ b/src/threadpool_log_config.h
@@ -2,6 +2,7 @@
 
 #include "utils/log.h"
 
+#define thpool_log_fatal(fmt, ...)  log_fatal(fmt __VA_OPT__(,) __VA_ARGS__)
 #define thpool_log_error(fmt, ...)  log_error(fmt __VA_OPT__(,) __VA_ARGS__)
 #define thpool_log_warn(fmt, ...)   log_warn(fmt __VA_OPT__(,) __VA_ARGS__)
 #define thpool_log_info(fmt, ...)   log_info(fmt __VA_OPT__(,) __VA_ARGS__)


### PR DESCRIPTION
Changes:
* API breaking change. Add `threadpool_thread` handle. User use the handle to get thread context and other thread metadata. Byebye `contain_of`.
* Introduce reference counting for `start_cb` arguments. Now users can use `thpool_thread_unref_callback_arg` in `start_cb` function to unref the callback arg as soon as they are no longer needed, effectively decoupling their lifetime from the thread pool's destroy.
* Use TSD to prevent user from misusing `thpool_wait`, `thpool_shutdown` and `thpool_destroy`. These APIs should not be called by the thread in the pool.

closes #2 
In the end, I think the thread-context mechanism now is OK. TSD is not always good. My realization provide explicit lifecycle hooks, centralized cleanup entry and lower barrier to use. Meanwhile, TSD leaves potential "uncertainty". Due to portability concerns regarding the unspecified order of TSD destructor execution across different POSIX implementations, this approach was not selected for managing critical thread context.