### PR TITLE
Refactor: Clarify C-only nature of nullptr macro

### DIFF
--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -44,11 +44,9 @@
 #include <errno.h>
 
 /* Use `nullptr` for backward portability.  */
-#if !defined(__cplusplus) && !defined(nullptr) && \
-   (!defined(__STDC_VERSION__) || __STDC_VERSION__ <= 201710)
-    #define nullptr ((void*)0)
+#if !defined(nullptr) && (!defined(__STDC_VERSION__) || __STDC_VERSION__ <= 201710)
+    #define nullptr ((void *)0)
 #endif
-
 
 /**
  * The header files below are only used for naming threads, for easier debugging.


### PR DESCRIPTION
Removes the redundant `!defined(__cplusplus)` guard from the `nullptr` macro definition in this .c source file. The `__cplusplus` macro is never defined by C compilers, making the guard functionally useless in a .c file. More importantly, its presence can **misleadingly suggest that this C source file is intended for C++ compilation**, which is not the case. This change clarifies the file's strict C compilation context and removes unnecessary preprocessor logic.